### PR TITLE
Change the image registry to eu.gcr.io/kyma-project/slack-bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMG ?= eu.gcr.io/kyma-project/incubator/slack-bot
+IMG ?= eu.gcr.io/kyma-project/slack-bot
 
 .PHONY: build-image
 build-image:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/kyma-project/incubator/slack-bot:latest
+image: eu.gcr.io/kyma-project/slack-bot:v20221222-b95bfb1b
 slack:
   # Slack App Token
   appToken: ""


### PR DESCRIPTION
followup to https://github.com/kyma-incubator/slack-bot/pull/15, despite the discussion on https://github.com/kyma-project/test-infra/pull/6626, the job actually pushes to `eu.gcr.io/kyma-project/slack-bot`

https://storage.googleapis.com/kyma-prow-logs/logs/merge-slack-bot-build/1605875050173435904/build-log.txt
```
...
Successfully built image: eu.gcr.io/kyma-project/slack-bot:v20221222-b95bfb1b
...
```